### PR TITLE
Fix market day data

### DIFF
--- a/src/entities/market-day-data.ts
+++ b/src/entities/market-day-data.ts
@@ -1,3 +1,4 @@
+import { BigInt, ethereum } from '@graphprotocol/graph-ts'
 import {
   MarketDayData,
   Market,
@@ -6,29 +7,21 @@ import {
   BorrowEvent,
   RepayEvent,
 } from '../types/schema'
-import { BigInt } from '@graphprotocol/graph-ts'
 import { Mint, Redeem, Borrow, RepayBorrow } from '../types/templates/JToken/JToken'
 import { zeroBD } from '../mappings/helpers'
 
-export function updateMarketDayDataMint(event: Mint): MarketDayData {
+export function getMarketDataData(event: ethereum.Event): MarketDayData {
   const timestamp = event.block.timestamp.toI32()
-
   const day = timestamp / 86400
-
   const id = event.address
     .toHexString()
     .concat('-')
     .concat(BigInt.fromI32(day).toString())
-  const mintID = event.transaction.hash
-    .toHexString()
-    .concat('-')
-    .concat(event.transactionLogIndex.toString())
 
-  const mintBlock = MintEvent.load(mintID)
   const market = Market.load(event.address.toHexString())
 
   let marketDayData = MarketDayData.load(id)
-  if (marketDayData === null) {
+  if (marketDayData == null) {
     marketDayData = new MarketDayData(id)
     marketDayData.date = day * 86400
     marketDayData.txCount = 0
@@ -36,140 +29,25 @@ export function updateMarketDayDataMint(event: Mint): MarketDayData {
     marketDayData.totalBorrowsUSD = zeroBD
     marketDayData.totalSupply = zeroBD
     marketDayData.totalSupplyUSD = zeroBD
-    marketDayData.totalReservesUSD = market.reserves.times(market.underlyingPriceUSD)
+    marketDayData.totalReservesUSD = zeroBD
     marketDayData.market = market.id
   }
-
-  marketDayData.txCount = marketDayData.txCount + 1
-  marketDayData.totalSupply = marketDayData.totalSupply.plus(mintBlock.amount)
-  marketDayData.totalSupplyUSD = marketDayData.totalSupplyUSD.plus(
-    mintBlock.underlyingAmount.times(market.underlyingPriceUSD),
-  )
-
   marketDayData.save()
-
   return marketDayData as MarketDayData
 }
 
-export function updateMarketDayDataRedeem(event: Redeem): MarketDayData {
-  const timestamp = event.block.timestamp.toI32()
-
-  const day = timestamp / 86400
-
-  const id = event.address
-    .toHexString()
-    .concat('-')
-    .concat(BigInt.fromI32(day).toString())
-  const mintID = event.transaction.hash
-    .toHexString()
-    .concat('-')
-    .concat(event.transactionLogIndex.toString())
-
-  const redeemBlock = RedeemEvent.load(mintID)
+export function updateMarketDayData(event: ethereum.Event): MarketDayData {
+  const marketDayData = getMarketDataData(event)
   const market = Market.load(event.address.toHexString())
 
-  let marketDayData = MarketDayData.load(id)
-  if (marketDayData === null) {
-    marketDayData = new MarketDayData(id)
-    marketDayData.date = day * 86400
-    marketDayData.txCount = 0
-    marketDayData.totalBorrows = zeroBD
-    marketDayData.totalBorrowsUSD = zeroBD
-    marketDayData.totalSupply = zeroBD
-    marketDayData.totalSupplyUSD = zeroBD
-    marketDayData.totalReservesUSD = market.reserves.times(market.underlyingPriceUSD)
-    marketDayData.market = market.id
-  }
-
   marketDayData.txCount = marketDayData.txCount + 1
-  marketDayData.totalSupply = marketDayData.totalSupply.minus(redeemBlock.amount)
-  marketDayData.totalSupplyUSD = marketDayData.totalSupplyUSD.minus(
-    redeemBlock.underlyingAmount.times(market.underlyingPriceUSD),
-  )
-
+  marketDayData.totalBorrows = market.totalBorrows
+  marketDayData.totalBorrowsUSD = market.totalBorrows.times(market.underlyingPriceUSD)
+  marketDayData.totalSupply = market.totalSupply
+  marketDayData.totalSupplyUSD = market.totalSupply
+    .times(market.exchangeRate)
+    .times(market.underlyingPriceUSD)
+  marketDayData.totalReservesUSD = market.reserves.times(market.underlyingPriceUSD)
   marketDayData.save()
-
-  return marketDayData as MarketDayData
-}
-
-export function updateMarketDayDataBorrow(event: Borrow): MarketDayData {
-  const timestamp = event.block.timestamp.toI32()
-
-  const day = timestamp / 86400
-
-  const id = event.address
-    .toHexString()
-    .concat('-')
-    .concat(BigInt.fromI32(day).toString())
-  const mintID = event.transaction.hash
-    .toHexString()
-    .concat('-')
-    .concat(event.transactionLogIndex.toString())
-
-  const borrowBlock = BorrowEvent.load(mintID)
-  const market = Market.load(event.address.toHexString())
-
-  let marketDayData = MarketDayData.load(id)
-  if (marketDayData === null) {
-    marketDayData = new MarketDayData(id)
-    marketDayData.date = day * 86400
-    marketDayData.txCount = 0
-    marketDayData.totalBorrows = zeroBD
-    marketDayData.totalBorrowsUSD = zeroBD
-    marketDayData.totalSupply = zeroBD
-    marketDayData.totalSupplyUSD = zeroBD
-    marketDayData.totalReservesUSD = market.reserves.times(market.underlyingPriceUSD)
-    marketDayData.market = market.id
-  }
-
-  marketDayData.txCount = marketDayData.txCount + 1
-  marketDayData.totalBorrows = marketDayData.totalBorrows.plus(borrowBlock.amount)
-  marketDayData.totalBorrowsUSD = marketDayData.totalBorrowsUSD.plus(
-    borrowBlock.amount.times(market.underlyingPriceUSD),
-  )
-
-  marketDayData.save()
-
-  return marketDayData as MarketDayData
-}
-
-export function updateMarketDayDataRepay(event: RepayBorrow): MarketDayData {
-  const timestamp = event.block.timestamp.toI32()
-
-  const day = timestamp / 86400
-
-  const id = event.address
-    .toHexString()
-    .concat('-')
-    .concat(BigInt.fromI32(day).toString())
-  const mintID = event.transaction.hash
-    .toHexString()
-    .concat('-')
-    .concat(event.transactionLogIndex.toString())
-
-  const repayBlock = RepayEvent.load(mintID)
-  const market = Market.load(event.address.toHexString())
-
-  let marketDayData = MarketDayData.load(id)
-  if (marketDayData === null) {
-    marketDayData = new MarketDayData(id)
-    marketDayData.date = day * 86400
-    marketDayData.txCount = 0
-    marketDayData.totalBorrows = zeroBD
-    marketDayData.totalBorrowsUSD = zeroBD
-    marketDayData.totalSupply = zeroBD
-    marketDayData.totalSupplyUSD = zeroBD
-    marketDayData.totalReservesUSD = market.reserves.times(market.underlyingPriceUSD)
-    marketDayData.market = market.id
-  }
-
-  marketDayData.txCount = marketDayData.txCount + 1
-  marketDayData.totalBorrows = marketDayData.totalBorrows.minus(repayBlock.amount)
-  marketDayData.totalBorrowsUSD = marketDayData.totalBorrowsUSD.minus(
-    repayBlock.amount.times(market.underlyingPriceUSD),
-  )
-
-  marketDayData.save()
-
   return marketDayData as MarketDayData
 }

--- a/src/mappings/jtoken.ts
+++ b/src/mappings/jtoken.ts
@@ -35,12 +35,7 @@ import {
   mantissaFactorBD,
   mantissaFactor,
 } from './helpers'
-import {
-  updateMarketDayDataMint,
-  updateMarketDayDataRedeem,
-  updateMarketDayDataBorrow,
-  updateMarketDayDataRepay,
-} from '../entities/market-day-data'
+import { updateMarketDayData } from '../entities/market-day-data'
 import { updateLiquidationDayData } from '../entities/liquidation-day-data'
 
 let network = dataSource.network()
@@ -92,8 +87,17 @@ export function handleMint(event: Mint): void {
   mint.underlyingAmount = underlyingAmount
   mint.save()
 
-  updateMarketDayDataMint(event)
+  updateMarketDayData(event)
 }
+
+/* Account borrows underlying tokens and pays a fee.
+ *
+ * event.params.receiver is the borrower
+ * event.params.amount is the underlying amount borrowed
+ * event.params.totalFee is the extra underlying amount paid as a fee
+ * event.params.reservesFee is the extra underlying amount that goes to reserves
+ *
+ */
 export function handleFlashloan(event: Flashloan): void {
   const marketID = event.address.toHex()
   const market = Market.load(marketID)
@@ -163,7 +167,7 @@ export function handleRedeem(event: Redeem): void {
   redeem.underlyingAmount = underlyingAmount
   redeem.save()
 
-  updateMarketDayDataRedeem(event)
+  updateMarketDayData(event)
 }
 
 /* Borrow assets from the protocol. All values either AVAX or ERC20
@@ -266,7 +270,7 @@ export function handleBorrow(event: Borrow): void {
   borrow.underlyingSymbol = market.underlyingSymbol
   borrow.save()
 
-  updateMarketDayDataBorrow(event)
+  updateMarketDayData(event)
 }
 
 /* Repay some amount borrowed. Anyone can repay anyones balance
@@ -374,7 +378,7 @@ export function handleRepayBorrow(event: RepayBorrow): void {
   repay.payer = event.params.payer
   repay.save()
 
-  updateMarketDayDataRepay(event)
+  updateMarketDayData(event)
 }
 
 /*


### PR DESCRIPTION
This PR changes the way `marketDayData` is updated. 

- Instead of calculating the changes in supply, borrows and reserves in each hook, it simply reads the latest values from `market`
- Also fixes `marketDayData.totalReservesUSD`, which was showing total reserves at the end of the day instead of the net reserves 