### PR TITLE
add missing contract addresses to avalanche

### DIFF
--- a/src/mappings/jtoken.ts
+++ b/src/mappings/jtoken.ts
@@ -40,12 +40,12 @@ import { updateLiquidationDayData } from '../entities/liquidation-day-data'
 
 let network = dataSource.network()
 const JOETROLLER_ADDRESS: string =
-  network === 'avalanche'
-    ? '0x0000000000000000000000000000000000000000' // avalanche
+  network == 'avalanche'
+    ? '0xdc13687554205E5b89Ac783db14bb5bba4A1eDaC' // avalanche
     : '0x5b0a2fa14808e34c5518e19f0dbc39f61d080b11' // rinkeby
 const JOELENS_ADDRESS: string =
-  network === 'avalanche'
-    ? '0x0000000000000000000000000000000000000000'
+  network == 'avalanche'
+    ? '0x997fbA28c75747417571c5F3fe50015AaC2BB073'
     : '0x4f101798dd4af8a2a8325f4c54c195a61c59dc62'
 
 /* Account supplies assets into market and receives jTokens in exchange

--- a/src/mappings/markets.ts
+++ b/src/mappings/markets.ts
@@ -29,12 +29,12 @@ let network = dataSource.network()
 
 let jAVAXAddress: string =
   network == 'avalanche'
-    ? '0x0000000000000000000000000000000000000000' // avalanche
+    ? '0xC22F01ddc8010Ee05574028528614634684EC29e' // avalanche
     : '0xaafe9d8346aefd57399e86d91bbfe256dc0dcac0' // rinkeby
 
 let jUSDCAddress =
   network == 'avalanche'
-    ? '0x0000000000000000000000000000000000000000' // avalanche
+    ? '0xEd6AaF91a2B084bd594DBd1245be3691F9f637aC' // avalanche
     : '0xe0447d1112ece174f2b351461367f9fbf9382661' // rinkeby
 
 let secondsPerYear = '31536000'


### PR DESCRIPTION
Added the missing contract addresses.

Also changed the network string comparison from
```
network === 'avalanche'
```
to
```
network == 'avalanche'
```
Since the first option seems to return False, even though I cannot explain why.