### PR TITLE
Change secondsPerTenMin from 60 to 600 seconds

### DIFF
--- a/src/mappings/markets.ts
+++ b/src/mappings/markets.ts
@@ -39,7 +39,7 @@ let jUSDCAddress =
 
 let secondsPerYear = '31536000'
 
-let secondsPerTenMin = 60
+let secondsPerTenMin = 600
 
 // Used for all jERC20 contracts
 function getUnderlyingPriceUSD(


### PR DESCRIPTION
Judging from the variable name and comments in the file, the following variable should be 600 seconds (10 minutes) instead of 60 (1 minute).